### PR TITLE
Update version to 5.1.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
 channels:
   - conda-forge
 dependencies:
-  - isort=4.3.21
+  - isort=5.1.1


### PR DESCRIPTION
The new `--ensure-newline-before-comments` flag would fix a conflict with `black=19.10b0` and close #1 .

